### PR TITLE
Add converted descriptions to window for use in console whenever the preview re-renders

### DIFF
--- a/src/components/itemPopup/Perks.tsx
+++ b/src/components/itemPopup/Perks.tsx
@@ -33,6 +33,11 @@ export function Perks() {
    const mainDescription = descriptionConverter(descriptionDataMain)
    const secondaryDescription = descriptionFilter(descriptionConverter(descriptionDataSecondary), 'dim')
 
+   // add current description objects to window for use in console
+   const win = window as any
+   win.mainDescription = mainDescription
+   win.secondaryDescription = secondaryDescription
+
    return (
       <div className={styles.perk_box}>
          <div className={styles.perk_list}>


### PR DESCRIPTION
Up to you if you want to accept this, I did it for my own usage and figured I might as well PR

All it does is add the `mainDescription` and `secondaryDescription` variables created on rendering the preview to `window` for use in the console.