### PR TITLE
Add kinetic damage type icon

### DIFF
--- a/src/components/itemPopup/Description.module.scss
+++ b/src/components/itemPopup/Description.module.scss
@@ -31,6 +31,7 @@
    margin: 0 1px;
    height: 10px;
 }
+.kinetic::before,
 .arc::before,
 .solar::before,
 .void::before,
@@ -59,6 +60,10 @@
 }
 
 //--- elements
+.kinetic::before {
+   background-image: url(https://www.bungie.net/common/destiny2_content/icons/DestinyDamageTypeDefinition_3385a924fd3ccb92c343ade19f19a370.png);
+   @include img_before;
+}
 .arc::before {
    background-image: url(https://www.bungie.net/common/destiny2_content/icons/DestinyDamageTypeDefinition_092d066688b879c807c3b460afdd61e6.png);
    @include img_before;

--- a/src/data/randomData.ts
+++ b/src/data/randomData.ts
@@ -4,6 +4,7 @@ const specialWrappers = ['green', 'blue', 'purple', 'yellow', 'center', 'bold', 
 
 export const wrappers = {
    imageAdding: [
+      'kinetic',
       'stasis',
       'arc',
       'solar',
@@ -59,7 +60,7 @@ export const defaultPerk: IntermediatePerk = {
 
 export const defaultDescription = `
 Images you can use in descriptions
-<arc/> <void/> <solar/>
+<kinetic/> <arc/> <void/> <solar/> <stasis/> <strand/>
 <primary/> <special/> <heavy/>
 <warlock/> <hunter/> <titan/>
 Text coloring


### PR DESCRIPTION
I was adding support for rendering other damage types in my app and wanted to ensure kinetic worked too but it wasn't a thing in Clarity yet, figured I'd add it. See https://github.com/Database-Clarity/Description-converter/pull/2